### PR TITLE
Prefer CMake norms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,19 +36,12 @@ if(NOT BUILD_SHARED_LIBS)
   set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries." FORCE)
 endif()
 
-project(lua C)
+project(lua VERSION 5.3.4 LANGUAGES C)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # Project options
 option(BUILD_LUA_INTERPRETER "Build the lua interpreter (lua)." ON)
 option(BUILD_LUA_COMPILER "Build the lua compiler (luac)." ON)
-
-# Version options
-set(LUA_VERSION_MAJOR "5" CACHE INTERNAL "Lua major version")
-set(LUA_VERSION_MINOR "3" CACHE INTERNAL "Lua minor version")
-set(LUA_VERSION_RELEASE "4" CACHE INTERNAL "Lua release version")
-set(LUA_VERSION "${LUA_VERSION_MAJOR}.${LUA_VERSION_MINOR}.${LUA_VERSION_RELEASE}"
-    CACHE INTERNAL "Lua version")
 
 # Install directories
 set(LUA_INSTALL_ROOT "")
@@ -57,7 +50,7 @@ set(LUA_INSTALL_LIB_DIR "lib")
 set(LUA_INSTALL_BIN_DIR "bin")
 set(LUA_INSTALL_CMAKE_DIR "lib/cmake/lua")
 
-message(STATUS "Lua: ${LUA_VERSION}")
+message(STATUS "Lua: ${lua_VERSION}")
 add_definitions(-DLUA_COMPAT_5_2)
 
 # Windows
@@ -115,7 +108,6 @@ add_subdirectory(src)
 set(version_file "${CMAKE_BINARY_DIR}/${LUA_INSTALL_CMAKE_DIR}/lua-config-version.cmake")
 write_basic_package_version_file(
   "${version_file}"
-  VERSION ${LUA_VERSION}
   COMPATIBILITY AnyNewerVersion
 )
 

--- a/cmake/lua-config.cmake.in
+++ b/cmake/lua-config.cmake.in
@@ -24,13 +24,13 @@
 
 @PACKAGE_INIT@
 
-set(LUA_ROOT "@PACKAGE_LUA_INSTALL_ROOT}" CACHE PATH "Install root of lua")
+set(LUA_ROOT "@PACKAGE_LUA_INSTALL_ROOT@" CACHE PATH "Install root of lua")
 
 # Import lua library
 include("@PACKAGE_LUA_INSTALL_CMAKE_DIR@/lua-lib-targets.cmake")
 set(LUA_INCLUDE_DIRS "@PACKAGE_LUA_INSTALL_INCLUDE_DIR@" CACHE PATH "Include directory of lua")
 
-get_property(__lua_lib TARGET lua::liblua PROPERTY LOCATION)
+get_property(__lua_lib TARGET lua::lua PROPERTY LOCATION)
 set(LUA_LIBRARIES "${__lua_lib}" CACHE BOOL "Path to the lua library")
 
 # Export compiler and interpreter
@@ -49,4 +49,4 @@ if(LUA_HAS_INTERPRETER)
 endif()
 
 # Report findings
-message(STATUS "Found Lua: ${LUA_LIBRARIES} (ver ${LUA_VERSION})") 
+message(STATUS "Found Lua: ${LUA_LIBRARIES} (ver ${lua_VERSION})")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,93 +22,97 @@
 #
 #*****************************************************************************#
 
-set(sources
-  # core 
-  lapi.c 
-  lcode.c 
-  lctype.c 
-  ldebug.c 
-  ldo.c 
-  ldump.c 
-  lfunc.c 
-  lgc.c 
-  llex.c 
-  lmem.c 
-  lobject.c 
+set(LUA_HEADERS
+  lua.h
+  luaconf.h
+  lualib.h
+  lauxlib.h
+  lua.hpp
+)
+
+set(LUA_CORE_SOURCE_FILES
+  lapi.c
+  lcode.c
+  lctype.c
+  ldebug.c
+  ldo.c
+  ldump.c
+  lfunc.c
+  lgc.c
+  llex.c
+  lmem.c
+  lobject.c
   lopcodes.c
-  lparser.c 
-  lstate.c 
-  lstring.c 
+  lparser.c
+  lstate.c
+  lstring.c
   ltable.c
-  ltm.c 
-  lundump.c 
-  lvm.c 
+  ltm.c
+  lundump.c
+  lvm.c
   lzio.c
-  
-  # lib
-  lauxlib.c 
-  lbaselib.c 
-  lbitlib.c 
-  lcorolib.c 
-  ldblib.c 
+)
+
+set(LUA_LIB_SOURCE_FILES
+  lauxlib.c
+  lbaselib.c
+  lbitlib.c
+  lcorolib.c
+  ldblib.c
   liolib.c
-  lmathlib.c 
-  loslib.c 
-  lstrlib.c 
-  ltablib.c 
-  lutf8lib.c 
-  loadlib.c 
+  lmathlib.c
+  loslib.c
+  lstrlib.c
+  ltablib.c
+  lutf8lib.c
+  loadlib.c
   linit.c
 )
 
-set(install_sources 
-  lua.h 
-  luaconf.h 
-  lualib.h 
-  lauxlib.h 
-  lua.hpp
+set(LUA_SOURCE_FILES
+  ${LUA_CORE_SOURCE_FILES}
+  ${LUA_LIB_SOURCE_FILES}
+  ${LUA_HEADERS}
 )
-install(FILES ${install_sources} DESTINATION include)
 
-add_library(lua_objects OBJECT ${sources})
+install(FILES ${LUA_HEADERS} DESTINATION include)
 
 # Lua library
-add_library(liblua $<TARGET_OBJECTS:lua_objects>)
-set_target_properties(liblua PROPERTIES OUTPUT_NAME lua)
-set_target_properties(liblua PROPERTIES VERSION "${LUA_VERSION}")
-set_target_properties(liblua PROPERTIES SOVERSION "${LUA_VERSION}")
+add_library(lua ${LUA_SOURCE_FILES})
+set_property(TARGET lua PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>
+)
+set_target_properties(lua PROPERTIES VERSION "${lua_VERSION}")
+set_target_properties(lua PROPERTIES SOVERSION "${lua_VERSION}")
 
 install(
-  TARGETS liblua 
+  TARGETS lua
   EXPORT lua-lib-targets
   RUNTIME DESTINATION ${LUA_INSTALL_BIN_DIR}
   LIBRARY DESTINATION ${LUA_INSTALL_LIB_DIR}
   ARCHIVE DESTINATION ${LUA_INSTALL_LIB_DIR}
 )
 install(
-  EXPORT lua-lib-targets 
-  NAMESPACE lua:: 
+  EXPORT lua-lib-targets
+  NAMESPACE lua::
   DESTINATION ${LUA_INSTALL_CMAKE_DIR}
   EXPORT_LINK_INTERFACE_LIBRARIES
 )
-        
+
 # Lua compiler
 if(BUILD_LUA_COMPILER)
-  if(WIN32 AND BUILD_SHARED_LIBS)
-    add_executable(luac ${sources} luac.c)
-  else()
-    add_executable(luac luac.c $<TARGET_OBJECTS:lua_objects>)
-    target_link_libraries(luac ${LUA_EXTERNAL_LIBS})
-  endif()
-  
+  add_executable(luac luac.c)
+  target_link_libraries(luac lua ${LUA_EXTERNAL_LIBS})
+
   install(
-    TARGETS luac 
-    EXPORT lua-compiler-targets 
+    TARGETS luac
+    EXPORT lua-compiler-targets
     RUNTIME DESTINATION ${LUA_INSTALL_BIN_DIR}
   )
   install(
-    EXPORT lua-compiler-targets 
-    NAMESPACE lua:: 
+    EXPORT lua-compiler-targets
+    NAMESPACE lua::
     DESTINATION ${LUA_INSTALL_CMAKE_DIR}
     EXPORT_LINK_INTERFACE_LIBRARIES
   )
@@ -116,21 +120,18 @@ endif()
 
 # Lua interpreter
 if(BUILD_LUA_INTERPRETER)
-  if(WIN32 AND BUILD_SHARED_LIBS)
-    add_executable(lua ${sources} lua.c)
-  else()
-    add_executable(lua lua.c $<TARGET_OBJECTS:lua_objects>)
-    target_link_libraries(lua ${LUA_EXTERNAL_LIBS})
-  endif()  
+  add_executable(luai lua.c)
+  set_target_properties(luai PROPERTIES OUTPUT_NAME lua)
+  target_link_libraries(luai lua ${LUA_EXTERNAL_LIBS})
 
   install(
-    TARGETS lua 
+    TARGETS luai
     EXPORT lua-interpreter-targets
     RUNTIME DESTINATION ${LUA_INSTALL_BIN_DIR}
   )
   install(
-    EXPORT lua-interpreter-targets 
-    NAMESPACE lua:: 
+    EXPORT lua-interpreter-targets
+    NAMESPACE lua::
     DESTINATION ${LUA_INSTALL_CMAKE_DIR}
     EXPORT_LINK_INTERFACE_LIBRARIES
   )


### PR DESCRIPTION
Use CMake project version instead of LUA_VERSION, and link with the 'lua' library instead of using its constituent objects.